### PR TITLE
refactor: dedup clicker code, harden IPC, add tests (v1.7.1)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,4 +27,4 @@ jobs:
         run: npm run lint
 
       - name: Check Prettier
-        run: npm run format -- --check
+        run: npm run format:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -28,3 +28,6 @@ jobs:
 
       - name: Check Prettier
         run: npm run format:check
+
+      - name: Run tests
+        run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,11 @@ npm run format:check        # Check formatting (read-only, used by CI)
 npm test                    # Run unit tests (node --test)
 ```
 
-**Testing**: Pure renderer logic lives in `lib/coordinates.js` and is covered by
-`test/coordinates.test.js` via the built-in `node --test` runner (no extra deps).
-Main-process and full renderer (Electron) flows are still untested — consider
-electron-mock / Playwright if expanding coverage.
+**Testing**: Pure coordinate logic (renderer UI helpers + main-process IPC
+validation via `sanitizeCoordinates`) lives in `lib/coordinates.js` and is
+covered by `test/coordinates.test.js` via the built-in `node --test` runner (no
+extra deps; CI runs it too). Electron-specific main/renderer flows are still
+untested — consider electron-mock / Playwright if expanding coverage.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Before declaring task complete, ALWAYS run:
 ```bash
 node --check main.js        # Check syntax
 npm run lint                # Must pass with no errors
-npm run format -- --check   # Optional format check
+npm run format:check        # Optional format check (read-only)
 ```
 
 Never mark complete if lint/syntax errors exist. Fix first, then report success. Exception: Non-code tasks (docs, git ops).
@@ -33,10 +33,15 @@ npm run build-win           # Full build: Windows .exe + runtime (работае
 npm run rebuild-asar        # Quick rebuild: только перепаковка кода в app.asar
 npm run lint                # Check for errors
 npm run lint:fix            # Auto-fix errors
-npm run format              # Format all files
+npm run format              # Format all files (writes)
+npm run format:check        # Check formatting (read-only, used by CI)
+npm test                    # Run unit tests (node --test)
 ```
 
-**Testing**: Not configured. Add Jest + electron-mock for main process, Playwright for renderer.
+**Testing**: Pure renderer logic lives in `lib/coordinates.js` and is covered by
+`test/coordinates.test.js` via the built-in `node --test` runner (no extra deps).
+Main-process and full renderer (Electron) flows are still untested — consider
+electron-mock / Playwright if expanding coverage.
 
 ---
 
@@ -53,7 +58,7 @@ npm run build-win           # Создаёт dist/win-unpacked/ с ClickerApp.ex
 ### Быстрая пересборка (после изменений в коде)
 
 ```bash
-npm run rebuild-asar        # Перепаковывает main.js, index.html и т.д. в app.asar
+npm run rebuild-asar        # Перепаковывает main.js, index.html, lib/ и т.д. в app.asar
 ```
 
 Используй это после правок кода — не нужна полная пересборка, только обновление `dist/win-unpacked/resources/app.asar`.
@@ -96,20 +101,20 @@ const path = require("path");
 
 **Available channels**:
 
-| Direction     | Channel                         | Purpose                    |
-| ------------- | ------------------------------- | -------------------------- |
-| Renderer→Main | `start-clicker`                 | Start mouse-only 10s       |
-| Renderer→Main | `start-clicker-infinite`        | Start mouse-only until ESC |
-| Renderer→Main | `start-hybrid-clicker`          | Start hybrid 10s           |
-| Renderer→Main | `start-hybrid-clicker-infinite` | Start hybrid until ESC     |
-| Renderer→Main | `start-moving-mouse`            | Start mouse move with click|
-| Renderer→Main | `stop-clicker`                  | Stop active process        |
-| Main→Renderer | `log`                           | Main process logs          |
-| Main→Renderer | `ps-output`                     | PowerShell stdout          |
-| Main→Renderer | `ps-error`                      | PowerShell stderr          |
-| Main→Renderer | `clicker-complete`              | Success notification       |
-| Main→Renderer | `clicker-error`                 | Error with message         |
-| Main→Renderer | `clicker-stopped`               | Stop notification          |
+| Direction     | Channel                         | Purpose                     |
+| ------------- | ------------------------------- | --------------------------- |
+| Renderer→Main | `start-clicker`                 | Start mouse-only 10s        |
+| Renderer→Main | `start-clicker-infinite`        | Start mouse-only until ESC  |
+| Renderer→Main | `start-hybrid-clicker`          | Start hybrid 10s            |
+| Renderer→Main | `start-hybrid-clicker-infinite` | Start hybrid until ESC      |
+| Renderer→Main | `start-moving-mouse`            | Start mouse move with click |
+| Renderer→Main | `stop-clicker`                  | Stop active process         |
+| Main→Renderer | `log`                           | Main process logs           |
+| Main→Renderer | `ps-output`                     | PowerShell stdout           |
+| Main→Renderer | `ps-error`                      | PowerShell stderr           |
+| Main→Renderer | `clicker-complete`              | Success notification        |
+| Main→Renderer | `clicker-error`                 | Error with message          |
+| Main→Renderer | `clicker-stopped`               | Stop notification           |
 
 ---
 
@@ -119,7 +124,7 @@ const path = require("path");
 
 - Handle OS ops via `child_process.spawn()`
 - Manage PowerShell scripts in temp directory
-- Send logs via `mainWindow.webContents.send()`
+- Send logs/messages to the renderer via the `sendToRenderer(channel, ...args)` helper (guards against a destroyed window); avoid calling `mainWindow.webContents.send()` directly
 
 **Renderer Process** (inline script in `index.html`):
 
@@ -138,10 +143,12 @@ fs.writeFileSync(scriptPath, code);
 const ps = spawn("powershell", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
   windowsHide: true,
 });
-ps.on("close", (code) => {
+ps.on("close", () => {
   try {
     fs.unlinkSync(scriptPath);
-  } catch (e) {}
+  } catch {
+    // temp file already gone — no-empty requires a comment, не пустой блок
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A simple application for automatic left mouse button clicking over a specified d
 
 Works great with [Bongo Cat](https://store.steampowered.com/app/3419430/Bongo_Cat/):
 
-| Per minute | Per hour | Per day |
-|:---:|:---:|:---:|
-| ~47,400 | ~2.8 million | **32+ million** ❗ |
+| Per minute |   Per hour   |      Per day       |
+| :--------: | :----------: | :----------------: |
+|  ~47,400   | ~2.8 million | **32+ million** ❗ |
 
 ![Clicks demo](docs/clicks.gif)
 

--- a/index.html
+++ b/index.html
@@ -203,7 +203,9 @@
       <button id="startMovingBtn" data-i18n="startMovingMouse" disabled>Start moving mouse</button>
     </div>
     <div id="status" data-i18n="pressToStart">Press to start</div>
-    <div class="escape-hint" id="escapeHint" style="display: none" data-i18n="pressEscToStop">Press ESC to stop</div>
+    <div class="escape-hint" id="escapeHint" style="display: none" data-i18n="pressEscToStop">
+      Press ESC to stop
+    </div>
 
     <div class="coordinate-section">
       <h2 data-i18n="cursorMovement">Cursor Movement by Coordinates</h2>
@@ -217,7 +219,9 @@
           value="5000"
           style="width: 100px"
         />
-        <button id="selectCoordBtn" class="select-coord-btn" data-i18n="addPoint">Add point by clicking</button>
+        <button id="selectCoordBtn" class="select-coord-btn" data-i18n="addPoint">
+          Add point by clicking
+        </button>
       </div>
       <div class="coordinates-list" id="coordinatesList">
         <div class="empty-list" data-i18n="noCoordinates">No coordinates</div>
@@ -226,6 +230,7 @@
 
     <script>
       const { ipcRenderer } = require("electron");
+      const CoordLib = require("./lib/coordinates.js");
       const startBtn = document.getElementById("startBtn");
       const startInfiniteBtn = document.getElementById("startInfiniteBtn");
       const startHybridBtn = document.getElementById("startHybridBtn");
@@ -387,7 +392,11 @@
       langSelect.value = currentLang;
 
       function t(key) {
-        return (translations[currentLang] && translations[currentLang][key]) || translations.en[key] || key;
+        return (
+          (translations[currentLang] && translations[currentLang][key]) ||
+          translations.en[key] ||
+          key
+        );
       }
 
       function applyTranslations() {
@@ -424,8 +433,8 @@
               <div style="font-family: monospace; font-size: 14px; margin-bottom: 5px">(${coord.x}, ${coord.y}) - ${t("interval")} ${coord.interval}ms</div>
               <div style="display: flex; align-items: center; gap: 5px">
                 <label style="font-size: 12px">${t("interval")}</label>
-                <input type="number" value="${coord.interval}" min="10" style="padding: 3px; width: 70px; font-size: 12px"
-                  onchange="updateCoordInterval(${index}, this.value)" />
+                <input type="number" value="${coord.interval}" min="10" data-index="${index}"
+                  class="interval-edit" style="padding: 3px; width: 70px; font-size: 12px" />
               </div>
             </div>
             <div style="display: flex; gap: 5px">
@@ -439,7 +448,7 @@
         document.querySelectorAll(".remove-btn").forEach((btn) => {
           btn.addEventListener("click", (e) => {
             const index = parseInt(e.target.dataset.index);
-            coordinates.splice(index, 1);
+            coordinates = CoordLib.removeCoordinate(coordinates, index);
             renderCoordinates();
           });
         });
@@ -452,18 +461,22 @@
             ipcRenderer.send("capture-mouse-click");
           });
         });
+        document.querySelectorAll(".interval-edit").forEach((input) => {
+          input.addEventListener("change", (e) => {
+            updateCoordInterval(parseInt(e.target.dataset.index), e.target.value);
+          });
+        });
       }
 
-      window.updateCoordInterval = function (index, value) {
-        const interval = parseInt(value);
-        if (isNaN(interval) || interval < 10) {
+      function updateCoordInterval(index, value) {
+        if (!CoordLib.isValidInterval(value)) {
           alert(t("intervalMin10"));
           renderCoordinates();
           return;
         }
-        coordinates[index].interval = interval;
+        coordinates = CoordLib.updateInterval(coordinates, index, value);
         renderCoordinates();
-      };
+      }
 
       selectCoordBtn.addEventListener("click", () => {
         console.log("Select coord button clicked");
@@ -475,11 +488,14 @@
       ipcRenderer.on("mouse-click-captured", (_event, { x, y }) => {
         console.log("Mouse coord captured:", x, y);
         if (editingIndex >= 0) {
-          coordinates[editingIndex] = { x, y, interval: coordinates[editingIndex].interval };
+          coordinates = CoordLib.replaceCoordinate(coordinates, editingIndex, { x, y });
           editingIndex = -1;
         } else {
-          const interval = parseInt(coordInterval.value) || 5000;
-          coordinates.push({ x, y, interval });
+          coordinates = CoordLib.addCoordinate(coordinates, {
+            x,
+            y,
+            interval: coordInterval.value,
+          });
         }
         renderCoordinates();
         selectCoordBtn.disabled = false;
@@ -516,7 +532,7 @@
       }
 
       function getCoords() {
-        return coordinates.length > 0 ? coordinates : null;
+        return CoordLib.getCoords(coordinates);
       }
 
       startBtn.addEventListener("click", () => {
@@ -592,18 +608,6 @@
 
       ipcRenderer.on("ps-error", (event, data) => {
         console.error("[PowerShell Error]:", data);
-      });
-
-      ipcRenderer.on("move-complete", () => {
-        console.log("Mouse move complete");
-      });
-
-      ipcRenderer.on("move-stopped", () => {
-        console.log("Mouse move stopped");
-      });
-
-      ipcRenderer.on("move-error", (event, error) => {
-        console.log("Mouse move error:", error);
       });
 
       // Apply translations on load

--- a/lib/coordinates.js
+++ b/lib/coordinates.js
@@ -1,0 +1,68 @@
+// Pure coordinate/interval logic for the renderer, extracted so it can be unit
+// tested without a DOM. Loaded in the renderer via require() (nodeIntegration is
+// enabled) and in tests via require() from test/.
+
+const DEFAULT_INTERVAL = 5000;
+const MIN_INTERVAL = 10;
+
+// Parse an interval value; returns an integer, or null when not a number.
+function parseInterval(value) {
+  const n = parseInt(value, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+// Whether an interval value is acceptable (numeric and >= MIN_INTERVAL).
+function isValidInterval(value) {
+  const n = parseInterval(value);
+  return n !== null && n >= MIN_INTERVAL;
+}
+
+// Append a captured point. Interval falls back to DEFAULT_INTERVAL when the
+// provided value is not a usable number (matches the old `parseInt() || 5000`).
+function addCoordinate(coords, point) {
+  const interval = parseInterval(point.interval) || DEFAULT_INTERVAL;
+  return coords.concat([{ x: point.x, y: point.y, interval }]);
+}
+
+// Replace the position of an existing coordinate, keeping its interval.
+function replaceCoordinate(coords, index, point) {
+  if (index < 0 || index >= coords.length) return coords;
+  const next = coords.slice();
+  next[index] = { x: point.x, y: point.y, interval: next[index].interval };
+  return next;
+}
+
+// Remove a coordinate by index.
+function removeCoordinate(coords, index) {
+  if (index < 0 || index >= coords.length) return coords;
+  const next = coords.slice();
+  next.splice(index, 1);
+  return next;
+}
+
+// Update the interval of a coordinate. Returns the list unchanged when the
+// interval is invalid (the caller surfaces the validation message).
+function updateInterval(coords, index, value) {
+  if (!isValidInterval(value)) return coords;
+  if (index < 0 || index >= coords.length) return coords;
+  const next = coords.slice();
+  next[index] = { ...next[index], interval: parseInterval(value) };
+  return next;
+}
+
+// Payload for the main process: the array, or null when empty.
+function getCoords(coords) {
+  return coords.length > 0 ? coords : null;
+}
+
+module.exports = {
+  DEFAULT_INTERVAL,
+  MIN_INTERVAL,
+  parseInterval,
+  isValidInterval,
+  addCoordinate,
+  replaceCoordinate,
+  removeCoordinate,
+  updateInterval,
+  getCoords,
+};

--- a/lib/coordinates.js
+++ b/lib/coordinates.js
@@ -1,9 +1,13 @@
-// Pure coordinate/interval logic for the renderer, extracted so it can be unit
-// tested without a DOM. Loaded in the renderer via require() (nodeIntegration is
-// enabled) and in tests via require() from test/.
+// Pure coordinate/interval logic, extracted so it can be unit tested without a
+// DOM or Electron. Loaded in the renderer via require() (nodeIntegration is
+// enabled), in the main process for IPC validation, and in tests from test/.
 
 const DEFAULT_INTERVAL = 5000;
 const MIN_INTERVAL = 10;
+// SetCursorPos takes int32; Start-Sleep -Milliseconds binds to a non-negative
+// Int32 — anything outside these ranges makes the PowerShell loop error forever.
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
 
 // Parse an interval value; returns an integer, or null when not a number.
 function parseInterval(value) {
@@ -18,7 +22,9 @@ function isValidInterval(value) {
 }
 
 // Append a captured point. Interval falls back to DEFAULT_INTERVAL when the
-// provided value is not a usable number (matches the old `parseInt() || 5000`).
+// provided value is not a usable number. Mirrors the old `parseInt() || 5000`,
+// except parseInt now gets an explicit radix 10, so hex strings like "0x1F" no
+// longer parse — unreachable through the number input anyway.
 function addCoordinate(coords, point) {
   const interval = parseInterval(point.interval) || DEFAULT_INTERVAL;
   return coords.concat([{ x: point.x, y: point.y, interval }]);
@@ -55,6 +61,29 @@ function getCoords(coords) {
   return coords.length > 0 ? coords : null;
 }
 
+// Validate a coordinates payload received over IPC in the main process: only
+// plain in-range integers may ever be interpolated into a PowerShell script.
+// Non-array payloads yield [], malformed entries are dropped, surviving values
+// are truncated and clamped into the ranges the generated script can handle.
+function sanitizeCoordinates(coords) {
+  if (!Array.isArray(coords)) return [];
+  return coords
+    .filter((c) => typeof c === "object" && c !== null)
+    .map((c) => ({
+      x: Math.trunc(Number(c.x)),
+      y: Math.trunc(Number(c.y)),
+      interval: Math.trunc(Number(c.interval)),
+    }))
+    .filter((c) => Number.isFinite(c.x) && Number.isFinite(c.y) && Number.isFinite(c.interval))
+    .map((c) => ({
+      x: Math.min(Math.max(c.x, INT32_MIN), INT32_MAX),
+      y: Math.min(Math.max(c.y, INT32_MIN), INT32_MAX),
+      // floor at MIN_INTERVAL, not 0: a stray sub-minimum interval must not
+      // turn the PowerShell move loop into a zero-sleep busy loop
+      interval: Math.min(Math.max(c.interval, MIN_INTERVAL), INT32_MAX),
+    }));
+}
+
 module.exports = {
   DEFAULT_INTERVAL,
   MIN_INTERVAL,
@@ -65,4 +94,5 @@ module.exports = {
   removeCoordinate,
   updateInterval,
   getCoords,
+  sanitizeCoordinates,
 };

--- a/main.js
+++ b/main.js
@@ -428,9 +428,18 @@ function runClickerScript({ name, script, event, reportExitCode }) {
     }
   });
 
+  // Spawn failures emit "error" without a matching "close", so mirror the
+  // cleanup here; when both fire, every step below is idempotent.
   ps.on("error", (err) => {
     sendToRenderer("log", `${name} error: ${err}`);
     if (clickerProcess === ps) clickerProcess = null;
+    stopMouseMove();
+    unregisterGlobalEsc();
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch {
+      // temp file already gone — nothing to clean up
+    }
     event.reply("clicker-error", err.message);
   });
 }
@@ -558,7 +567,13 @@ ${clickerClass}
     sendToRenderer("ps-error", data.toString());
   });
 
-  ps.on("close", () => {
+  // Shared by "close" and "error": a spawn failure emits "error" without a
+  // matching "close", and both can fire for runtime errors — settle only once
+  // so onClose (completion reply) is never skipped or duplicated.
+  let settled = false;
+  const settle = () => {
+    if (settled) return;
+    settled = true;
     if (moveProcess === ps) moveProcess = null;
     try {
       fs.unlinkSync(scriptPath);
@@ -566,11 +581,13 @@ ${clickerClass}
       // temp file already gone — nothing to clean up
     }
     if (onClose) onClose();
-  });
+  };
+
+  ps.on("close", settle);
 
   ps.on("error", (err) => {
     sendToRenderer("log", "Mouse move error: " + err);
-    if (moveProcess === ps) moveProcess = null;
+    settle();
   });
 
   return true;
@@ -737,6 +754,12 @@ while ($true) {
   });
 
   ps.on("error", (err) => {
+    // spawn failures emit "error" without "close" — clean the temp file here too
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch {
+      // temp file already gone — nothing to clean up
+    }
     event.reply("mouse-click-error", err.message);
   });
 });

--- a/main.js
+++ b/main.js
@@ -3,10 +3,12 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
+const { sanitizeCoordinates } = require("./lib/coordinates.js");
 
 let mainWindow;
 let clickerProcess = null;
 let moveProcess = null;
+let captureProcess = null;
 
 // Safe send to the renderer: the window may already be destroyed when a
 // PowerShell process exits during shutdown, so guard every send.
@@ -57,6 +59,7 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     releaseAllKeys();
     stopMouseMove();
+    stopCaptureProcess();
     if (clickerProcess) {
       spawn("taskkill", ["/PID", String(clickerProcess.pid), "/T", "/F"]);
       clickerProcess = null;
@@ -71,14 +74,25 @@ app.on("activate", () => {
   }
 });
 
+// Date.now() alone can collide when two scripts are requested within the same
+// millisecond (e.g. rapid capture requests), so add a monotonic counter.
+let scriptSeq = 0;
 function uniqueScriptPath(name) {
-  return path.join(os.tmpdir(), `${name}-${Date.now()}.ps1`);
+  scriptSeq++;
+  return path.join(os.tmpdir(), `${name}-${Date.now()}-${scriptSeq}.ps1`);
 }
 
 function stopMouseMove() {
   if (moveProcess) {
     spawn("taskkill", ["/PID", String(moveProcess.pid), "/T", "/F"]);
     moveProcess = null;
+  }
+}
+
+function stopCaptureProcess() {
+  if (captureProcess) {
+    spawn("taskkill", ["/PID", String(captureProcess.pid), "/T", "/F"]);
+    captureProcess = null;
   }
 }
 
@@ -408,6 +422,16 @@ function runClickerScript({ name, script, event, reportExitCode }) {
     sendToRenderer("ps-error", data.toString());
   });
 
+  // A failed spawn emits "error" and then "close" as well, so both handlers can
+  // fire for one process. The cleanup steps are idempotent; replyOnce makes
+  // sure the renderer sees exactly one final clicker-* reply.
+  let replied = false;
+  const replyOnce = (channel, ...args) => {
+    if (replied) return;
+    replied = true;
+    event.reply(channel, ...args);
+  };
+
   ps.on("close", (code) => {
     sendToRenderer("log", `${name} closed with code: ${code}`);
     const wasKilled = clickerProcess !== ps;
@@ -420,16 +444,14 @@ function runClickerScript({ name, script, event, reportExitCode }) {
       // temp file already gone — nothing to clean up
     }
     if (wasKilled) {
-      event.reply("clicker-stopped");
+      replyOnce("clicker-stopped");
     } else if (!reportExitCode || code === 0) {
-      event.reply("clicker-complete");
+      replyOnce("clicker-complete");
     } else {
-      event.reply("clicker-error", `Exit code: ${code}`);
+      replyOnce("clicker-error", `Exit code: ${code}`);
     }
   });
 
-  // Spawn failures emit "error" without a matching "close", so mirror the
-  // cleanup here; when both fire, every step below is idempotent.
   ps.on("error", (err) => {
     sendToRenderer("log", `${name} error: ${err}`);
     if (clickerProcess === ps) clickerProcess = null;
@@ -440,7 +462,7 @@ function runClickerScript({ name, script, event, reportExitCode }) {
     } catch {
       // temp file already gone — nothing to clean up
     }
-    event.reply("clicker-error", err.message);
+    replyOnce("clicker-error", err.message);
   });
 }
 
@@ -460,23 +482,12 @@ function isClickerBusy(channel) {
 // mode to signal completion without polling.
 function startMouseMoveIfNeeded(coords, withClick = false, onClose = null) {
   sendToRenderer("log", "startMouseMoveIfNeeded called, coords: " + JSON.stringify(coords));
-  if (!coords || coords.length === 0) {
-    sendToRenderer("log", "No coordinates, skipping mouse move");
-    return false;
-  }
 
-  // Validate IPC data: coerce to integers and drop anything non-numeric so
-  // nothing but plain numbers is ever interpolated into the PowerShell script.
-  const sanitized = coords
-    .map((c) => ({
-      x: Math.trunc(Number(c.x)),
-      y: Math.trunc(Number(c.y)),
-      interval: Math.trunc(Number(c.interval)),
-    }))
-    .filter((c) => Number.isFinite(c.x) && Number.isFinite(c.y) && Number.isFinite(c.interval));
-
+  // Validate IPC data (including a non-array payload) so nothing but plain
+  // in-range integers is ever interpolated into the PowerShell script.
+  const sanitized = sanitizeCoordinates(coords);
   if (sanitized.length === 0) {
-    sendToRenderer("log", "No valid coordinates after validation, skipping mouse move");
+    sendToRenderer("log", "No valid coordinates, skipping mouse move");
     return false;
   }
 
@@ -596,7 +607,6 @@ ${clickerClass}
 ipcMain.on("start-moving-mouse", (event, data) => {
   if (isClickerBusy("start-moving-mouse")) return;
   sendToRenderer("log", "Start moving mouse requested");
-  registerGlobalEsc();
 
   const finish = () => {
     unregisterGlobalEsc();
@@ -605,8 +615,14 @@ ipcMain.on("start-moving-mouse", (event, data) => {
 
   // The mover runs an infinite loop, so completion only happens when the
   // process is killed (ESC / stop). Signal via the process close event.
-  const started = startMouseMoveIfNeeded(data.coordinates, true, finish);
-  if (!started) finish();
+  // Register the global shortcut only after a successful start: if the spawn
+  // throws, Escape must not stay grabbed with nothing running.
+  const started = startMouseMoveIfNeeded(data && data.coordinates, true, finish);
+  if (!started) {
+    event.reply("clicker-complete");
+    return;
+  }
+  registerGlobalEsc();
 });
 
 ipcMain.on("start-clicker", (event, data) => {
@@ -672,6 +688,10 @@ ipcMain.on("start-hybrid-clicker-infinite", (event, data) => {
 });
 
 ipcMain.on("capture-mouse-click", (event) => {
+  // Only one capture poller at a time: a new request (e.g. another "Change
+  // position" click) supersedes the previous one, which would otherwise keep
+  // polling until the next physical click and reply a second time.
+  stopCaptureProcess();
   sendToRenderer("log", "Waiting for mouse click to capture coordinates...");
 
   const script = `
@@ -723,6 +743,7 @@ while ($true) {
   const ps = spawn("powershell.exe", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
     windowsHide: true,
   });
+  captureProcess = ps;
 
   ps.stdout.on("data", (data) => {
     output += data.toString();
@@ -746,6 +767,7 @@ while ($true) {
   });
 
   ps.on("close", () => {
+    if (captureProcess === ps) captureProcess = null;
     try {
       fs.unlinkSync(scriptPath);
     } catch {
@@ -754,7 +776,8 @@ while ($true) {
   });
 
   ps.on("error", (err) => {
-    // spawn failures emit "error" without "close" — clean the temp file here too
+    // a failed spawn emits "error" before "close" — clean up here too (idempotent)
+    if (captureProcess === ps) captureProcess = null;
     try {
       fs.unlinkSync(scriptPath);
     } catch {

--- a/main.js
+++ b/main.js
@@ -8,6 +8,34 @@ let mainWindow;
 let clickerProcess = null;
 let moveProcess = null;
 
+// Safe send to the renderer: the window may already be destroyed when a
+// PowerShell process exits during shutdown, so guard every send.
+function sendToRenderer(channel, ...args) {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(channel, ...args);
+  }
+}
+
+// Single source of truth for the hybrid clicker key set.
+// NEVER add F1-F12 (0x70-0x7B) — they break the game (Bongo Cat).
+const HYBRID_KEYS = [
+  0x25, 0x26, 0x27, 0x28, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0xbd, 0xbb,
+  0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6d, 0x6e, 0x6f, 0x41,
+  0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50, 0x51,
+  0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0xba, 0xbf, 0xc0, 0xdb, 0xdc, 0xdd, 0xde,
+  0xbc, 0xbe, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x20, 0x08,
+  0x2d, 0x2e, 0x24, 0x23, 0x21, 0x22,
+];
+
+// Alpha keys (A-Z) used for the shift-combo batch — derived from HYBRID_KEYS so
+// the two sets can never drift apart.
+const HYBRID_ALPHA_KEYS = HYBRID_KEYS.filter((k) => k >= 0x41 && k <= 0x5a);
+
+// Format a JS array of byte values as a C# byte[] initializer body.
+function toCSharpBytes(bytes) {
+  return bytes.map((b) => "0x" + b.toString(16).toUpperCase().padStart(2, "0")).join(", ");
+}
+
 function createWindow() {
   Menu.setApplicationMenu(null);
 
@@ -79,17 +107,7 @@ public class KeyReleaser {
 
     // Release all keys used by hybrid clicker
     byte[] keys = new byte[] {
-      0x25, 0x26, 0x27, 0x28,
-      0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
-      0xBD, 0xBB,
-      0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
-      0x6A, 0x6B, 0x6D, 0x6E, 0x6F,
-      0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A,
-      0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54,
-      0x55, 0x56, 0x57, 0x58, 0x59, 0x5A,
-      0xBA, 0xBF, 0xC0, 0xDB, 0xDC, 0xDD, 0xDE, 0xBC, 0xBE,
-      0x7C, 0x7D, 0x7E, 0x7F, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
-      0x20, 0x08, 0x2D, 0x2E, 0x24, 0x23, 0x21, 0x22
+      ${toCSharpBytes(HYBRID_KEYS)}
     };
     for (int i = 0; i < keys.Length; i++)
       keybd_event(keys[i], 0, KEYEVENTF_KEYUP, 0);
@@ -104,26 +122,30 @@ public class KeyReleaser {
     windowsHide: true,
   });
   ps.on("close", () => {
-    try { fs.unlinkSync(scriptPath); } catch (_e) { _e; }
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch {
+      // temp file already gone — nothing to clean up
+    }
   });
 }
 
 function registerGlobalEsc() {
   try {
     globalShortcut.register("Escape", () => {
-      mainWindow.webContents.send("log", "Global ESC pressed");
+      sendToRenderer("log", "Global ESC pressed");
       ipcMain.emit("stop-clicker");
     });
-  } catch (_e) {
-    _e;
+  } catch {
+    // shortcut not registered — safe to ignore
   }
 }
 
 function unregisterGlobalEsc() {
   try {
     globalShortcut.unregister("Escape");
-  } catch (_e) {
-    _e;
+  } catch {
+    // shortcut not registered — safe to ignore
   }
 }
 
@@ -161,370 +183,9 @@ const SENDINPUT_TYPES = `
   public static readonly int inputSize = Marshal.SizeOf(typeof(INPUT));
 `;
 
-function startMouseMoveIfNeeded(coords, withClick = false) {
-  mainWindow.webContents.send(
-    "log",
-    "startMouseMoveIfNeeded called, coords: " + JSON.stringify(coords)
-  );
-  if (!coords || coords.length === 0) {
-    mainWindow.webContents.send("log", "No coordinates, skipping mouse move");
-    return;
-  }
-
-  const coordsArray = coords
-    .map((c) => `[PSCustomObject]@{X=${c.x};Y=${c.y};Interval=${c.interval}}`)
-    .join(",");
-
-  const clickerClass = withClick ? `
-public class MouseClicker {
-  [DllImport("user32.dll")]
-  public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint cButtons, uint dwExtraInfo);
-
-  public const uint MOUSEEVENTF_LEFTDOWN = 0x02;
-  public const uint MOUSEEVENTF_LEFTUP = 0x04;
-
-  public static void Click() {
-    mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
-    Thread.Sleep(20);
-    mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
-    Thread.Sleep(10);
-  }
-}` : '';
-
-  const clickCall = withClick ? `\n      [MouseClicker]::Click()` : '';
-
-  const moveScript = `
-try {
-  Write-Output "Starting mouse mover with ${coords.length} coordinates..."
-  Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-public class MouseMover {
-  [DllImport("user32.dll", SetLastError = true)]
-  public static extern bool SetCursorPos(int x, int y);
-
-  public static void MoveTo(int x, int y) {
-    SetCursorPos(x, y);
-  }
-}
-${clickerClass}
-'@
-
-  Write-Output "Mouse mover class loaded successfully"
-  $coordinates = @(${coordsArray})
-  $index = 0
-  while ($true) {
-    try {
-      $coord = $coordinates[$index]
-      $x = $coord.X
-      $y = $coord.Y
-      $interval = $coord.Interval
-      Write-Output "Moving to: X=$x, Y=$y"
-      [MouseMover]::MoveTo($x, $y)${clickCall}
-      Start-Sleep -Milliseconds $interval
-      $index++
-      if ($index -ge $coordinates.Length) {
-        $index = 0
-      }
-    } catch {
-      Write-Output "Move error: $_"
-    }
-  }
-} catch {
-  Write-Output "Fatal error: $_"
-}
-`;
-
-  const scriptPath = uniqueScriptPath("mouse-move");
-  fs.writeFileSync(scriptPath, moveScript);
-  mainWindow.webContents.send("log", "Mouse move script: " + scriptPath);
-
-  const ps = spawn("powershell.exe", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
-    windowsHide: true,
-  });
-  moveProcess = ps;
-
-  mainWindow.webContents.send("log", "Mouse move started with PID: " + ps.pid);
-
-  ps.stdout.on("data", (data) => {
-    mainWindow.webContents.send("ps-output", data.toString());
-  });
-
-  ps.stderr.on("data", (data) => {
-    mainWindow.webContents.send("ps-error", data.toString());
-  });
-
-  ps.on("close", () => {
-    if (moveProcess === ps) moveProcess = null;
-    try {
-      fs.unlinkSync(scriptPath);
-    } catch (_e) {
-      _e;
-    }
-  });
-
-  ps.on("error", (err) => {
-    mainWindow.webContents.send("log", "Mouse move error: " + err);
-    if (moveProcess === ps) moveProcess = null;
-  });
-}
-
-ipcMain.on("start-moving-mouse", (event, data) => {
-  mainWindow.webContents.send("log", "Start moving mouse requested");
-  startMouseMoveIfNeeded(data.coordinates, true);
-  registerGlobalEsc();
-
-  const checkInterval = setInterval(() => {
-    if (!moveProcess) {
-      clearInterval(checkInterval);
-      unregisterGlobalEsc();
-      event.reply("clicker-complete");
-    }
-  }, 500);
-});
-
-ipcMain.on("start-clicker", (event, data) => {
-  mainWindow.webContents.send("log", "IPC start-clicker received, data: " + JSON.stringify(data));
-  if (data) startMouseMoveIfNeeded(data.coordinates);
-
-  const powerShellScript = `
-try {
-  Write-Output "Starting clicker for 10 seconds..."
-  Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-public class MouseClicker {
-  [DllImport("user32.dll")]
-  public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint cButtons, uint dwExtraInfo);
-
-  public const uint MOUSEEVENTF_LEFTDOWN = 0x02;
-  public const uint MOUSEEVENTF_LEFTUP = 0x04;
-
-  public static void Click() {
-    mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
-    Thread.Sleep(20);
-    mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
-    Thread.Sleep(10);
-  }
-
-  public static void ClickWithDelay() {
-    Click();
-  }
-}
-'@
-  Write-Output "Clicker class loaded successfully"
-  $startTime = Get-Date
-  $endTime = $startTime.AddSeconds(10)
-  Write-Output "Start time: $startTime"
-  Write-Output "End time: $endTime"
-  $count = 0
-  while ($true) {
-    $currentTime = Get-Date
-    if ($currentTime -ge $endTime) {
-      Write-Output "Time limit reached"
-      break
-    }
-    try {
-      [MouseClicker]::ClickWithDelay()
-      $count++
-      if ($count % 10 -eq 0) {
-        Write-Output "Clicked $count times at $currentTime"
-      }
-    } catch {
-      Write-Output "Click error: $_"
-      Write-Output "Stack: $($_.ScriptStackTrace)"
-    }
-  }
-  Write-Output "Done. Total clicks: $count"
-} catch {
-  Write-Output "Fatal error: $_"
-  Write-Output "Stack: $($_.ScriptStackTrace)"
-}
-`;
-
-  mainWindow.webContents.send("log", "Creating temp directory script...");
-  const scriptPath = uniqueScriptPath("clicker");
-  mainWindow.webContents.send("log", "Script path: " + scriptPath);
-  fs.writeFileSync(scriptPath, powerShellScript);
-  mainWindow.webContents.send("log", "Script written successfully");
-
-  mainWindow.webContents.send("log", "Starting PowerShell process...");
-
-  const ps = spawn("powershell.exe", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
-    windowsHide: true,
-  });
-  clickerProcess = ps;
-  registerGlobalEsc();
-
-  mainWindow.webContents.send("log", "PowerShell process started with PID: " + ps.pid);
-
-  ps.stdout.on("data", (data) => {
-    mainWindow.webContents.send("ps-output", data.toString());
-  });
-
-  ps.stderr.on("data", (data) => {
-    mainWindow.webContents.send("ps-error", data.toString());
-  });
-
-  ps.on("close", (code) => {
-    mainWindow.webContents.send("log", "Clicker closed with code: " + code);
-    const wasKilled = clickerProcess !== ps;
-    if (clickerProcess === ps) clickerProcess = null;
-    stopMouseMove();
-    unregisterGlobalEsc();
-    try {
-      fs.unlinkSync(scriptPath);
-    } catch (_e) {
-      _e;
-    }
-    if (wasKilled) {
-      event.reply("clicker-stopped");
-    } else if (code === 0) {
-      event.reply("clicker-complete");
-    } else {
-      event.reply("clicker-error", `Exit code: ${code}`);
-    }
-  });
-
-  ps.on("error", (err) => {
-    mainWindow.webContents.send("log", "Clicker error: " + err);
-    if (clickerProcess === ps) clickerProcess = null;
-    event.reply("clicker-error", err.message);
-  });
-});
-
-ipcMain.on("start-clicker-infinite", (event, data) => {
-  mainWindow.webContents.send("log", "IPC start-clicker-infinite received");
-  if (data) startMouseMoveIfNeeded(data.coordinates);
-
-  const powerShellScript = `
-try {
- Write-Output "Starting infinite clicker (ESC to stop)..."
- Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-public class MouseClicker {
-  [DllImport("user32.dll")]
-  public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint cButtons, uint dwExtraInfo);
-
-  public const uint MOUSEEVENTF_LEFTDOWN = 0x02;
-  public const uint MOUSEEVENTF_LEFTUP = 0x04;
-
-  public static void Click() {
-    mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
-    Thread.Sleep(20);
-    mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
-    Thread.Sleep(10);
-  }
-
-  public static void ClickWithDelay() {
-    Click();
-  }
-}
-'@
-
-  Write-Output "Clicker class loaded successfully"
-  $count = 0
-  while ($true) {
-    try {
-      [MouseClicker]::ClickWithDelay()
-      $count++
-      if ($count % 10 -eq 0) {
-        Write-Output "Clicked $count times"
-      }
-    } catch {
-      Write-Output "Click error: $_"
-      Write-Output "Stack: $($_.ScriptStackTrace)"
-    }
-  }
-} catch {
-  Write-Output "Fatal error: $_"
-  Write-Output "Stack: $($_.ScriptStackTrace)"
-}
-`;
-
-  mainWindow.webContents.send("log", "Creating temp directory script...");
-  const scriptPath = uniqueScriptPath("clicker-infinite");
-  mainWindow.webContents.send("log", "Script path: " + scriptPath);
-  fs.writeFileSync(scriptPath, powerShellScript);
-  mainWindow.webContents.send("log", "Script written successfully");
-
-  mainWindow.webContents.send("log", "Starting PowerShell process...");
-
-  const ps = spawn("powershell.exe", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
-    windowsHide: true,
-  });
-  clickerProcess = ps;
-  registerGlobalEsc();
-
-  mainWindow.webContents.send("log", "PowerShell process started with PID: " + ps.pid);
-
-  ps.stdout.on("data", (data) => {
-    mainWindow.webContents.send("ps-output", data.toString());
-  });
-
-  ps.stderr.on("data", (data) => {
-    mainWindow.webContents.send("ps-error", data.toString());
-  });
-
-  ps.on("close", (code) => {
-    mainWindow.webContents.send("log", "Clicker-infinite closed with code: " + code);
-    const wasKilled = clickerProcess !== ps;
-    if (clickerProcess === ps) clickerProcess = null;
-    stopMouseMove();
-    unregisterGlobalEsc();
-    try {
-      fs.unlinkSync(scriptPath);
-    } catch (_e) {
-      _e;
-    }
-    if (wasKilled) {
-      event.reply("clicker-stopped");
-    } else {
-      event.reply("clicker-complete");
-    }
-  });
-
-  ps.on("error", (err) => {
-    mainWindow.webContents.send("log", "Clicker-infinite error: " + err);
-    if (clickerProcess === ps) clickerProcess = null;
-    event.reply("clicker-error", err.message);
-  });
-});
-
-ipcMain.on("stop-clicker", () => {
-  mainWindow.webContents.send("log", "Stop clicker requested");
-  const hadClicker = !!clickerProcess;
-  if (clickerProcess) {
-    mainWindow.webContents.send("log", "Killing clicker PID: " + clickerProcess.pid);
-    spawn("taskkill", ["/PID", String(clickerProcess.pid), "/T", "/F"]);
-    clickerProcess = null;
-    releaseAllKeys();
-  }
-  if (moveProcess) {
-    mainWindow.webContents.send("log", "Killing move PID: " + moveProcess.pid);
-    spawn("taskkill", ["/PID", String(moveProcess.pid), "/T", "/F"]);
-    moveProcess = null;
-  }
-  if (!hadClicker) {
-    mainWindow.webContents.send("clicker-stopped");
-  }
-});
-
-ipcMain.on("start-hybrid-clicker", (event, data) => {
-  mainWindow.webContents.send("log", "IPC start-hybrid-clicker received");
-  if (data) startMouseMoveIfNeeded(data.coordinates);
-
-  const powerShellScript = `
-try {
-  Add-Type -TypeDefinition @'
-using System;
+// Shared C# HybridClicker class (used by both timed and infinite modes).
+// Exposes Smash() for one cycle and RunTimed(seconds) for the timed loop.
+const HYBRID_CLICKER_CLASS = `using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -533,23 +194,11 @@ public class HybridClicker {
 ${SENDINPUT_TYPES}
 
   private static readonly byte[] keys = new byte[] {
-    0x25, 0x26, 0x27, 0x28,
-    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
-    0xBD, 0xBB,
-    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
-    0x6A, 0x6B, 0x6D, 0x6E, 0x6F,
-    0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A,
-    0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54,
-    0x55, 0x56, 0x57, 0x58, 0x59, 0x5A,
-    0xBA, 0xBF, 0xC0, 0xDB, 0xDC, 0xDD, 0xDE, 0xBC, 0xBE,
-    0x7C, 0x7D, 0x7E, 0x7F, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
-    0x20, 0x08, 0x2D, 0x2E, 0x24, 0x23, 0x21, 0x22
+    ${toCSharpBytes(HYBRID_KEYS)}
   };
 
   private static readonly byte[] alphaKeys = new byte[] {
-    0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A,
-    0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54,
-    0x55, 0x56, 0x57, 0x58, 0x59, 0x5A
+    ${toCSharpBytes(HYBRID_ALPHA_KEYS)}
   };
 
   private static readonly INPUT[] batch1Press;
@@ -597,161 +246,6 @@ ${SENDINPUT_TYPES}
     batch2Release[alphaKeys.Length].u.ki.dwFlags = 0x0002;
   }
 
-  public static string RunTimed(int seconds) {
-    Stopwatch sw = Stopwatch.StartNew();
-    long cycles = 0;
-    long targetMs = seconds * 1000L;
-    while (sw.ElapsedMilliseconds < targetMs) {
-      SendInput((uint)batch1Press.Length, batch1Press, inputSize);
-      Thread.Sleep(15);
-      SendInput((uint)batch1Release.Length, batch1Release, inputSize);
-      Thread.Sleep(10);
-      SendInput((uint)batch2Press.Length, batch2Press, inputSize);
-      Thread.Sleep(15);
-      SendInput((uint)batch2Release.Length, batch2Release, inputSize);
-      Thread.Sleep(10);
-      cycles++;
-    }
-    sw.Stop();
-    long totalActions = cycles * actionsPerCycle;
-    return "Done. Cycles: " + cycles + ", Total actions: " + totalActions + " in " + sw.ElapsedMilliseconds + "ms";
-  }
-}
-'@
-  Write-Output ([HybridClicker]::RunTimed(10))
-} catch {
-  Write-Output "Fatal error: $_"
-  Write-Output "Stack: $($_.ScriptStackTrace)"
-}
-`;
-
-  mainWindow.webContents.send("log", "Creating temp directory script...");
-  const scriptPath = uniqueScriptPath("hybrid-clicker");
-  mainWindow.webContents.send("log", "Script path: " + scriptPath);
-  fs.writeFileSync(scriptPath, powerShellScript);
-  mainWindow.webContents.send("log", "Script written successfully");
-
-  mainWindow.webContents.send("log", "Starting PowerShell process...");
-
-  const ps = spawn("powershell.exe", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
-    windowsHide: true,
-  });
-  clickerProcess = ps;
-  registerGlobalEsc();
-
-  mainWindow.webContents.send("log", "PowerShell process started with PID: " + ps.pid);
-
-  ps.stdout.on("data", (data) => {
-    mainWindow.webContents.send("ps-output", data.toString());
-  });
-
-  ps.stderr.on("data", (data) => {
-    mainWindow.webContents.send("ps-error", data.toString());
-  });
-
-  ps.on("close", (code) => {
-    mainWindow.webContents.send("log", "Hybrid clicker closed with code: " + code);
-    const wasKilled = clickerProcess !== ps;
-    if (clickerProcess === ps) clickerProcess = null;
-    stopMouseMove();
-    unregisterGlobalEsc();
-    try {
-      fs.unlinkSync(scriptPath);
-    } catch (_e) {
-      _e;
-    }
-    if (wasKilled) {
-      event.reply("clicker-stopped");
-    } else if (code === 0) {
-      event.reply("clicker-complete");
-    } else {
-      event.reply("clicker-error", `Exit code: ${code}`);
-    }
-  });
-
-  ps.on("error", (err) => {
-    mainWindow.webContents.send("log", "Hybrid clicker error: " + err);
-    if (clickerProcess === ps) clickerProcess = null;
-    event.reply("clicker-error", err.message);
-  });
-});
-
-ipcMain.on("start-hybrid-clicker-infinite", (event, data) => {
-  mainWindow.webContents.send("log", "IPC start-hybrid-clicker-infinite received");
-  if (data) startMouseMoveIfNeeded(data.coordinates);
-
-  const powerShellScript = `
-try {
-  Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-using System.Threading;
-
-public class HybridClicker {
-${SENDINPUT_TYPES}
-
-  private static readonly byte[] keys = new byte[] {
-    0x25, 0x26, 0x27, 0x28,
-    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
-    0xBD, 0xBB,
-    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
-    0x6A, 0x6B, 0x6D, 0x6E, 0x6F,
-    0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A,
-    0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54,
-    0x55, 0x56, 0x57, 0x58, 0x59, 0x5A,
-    0xBA, 0xBF, 0xC0, 0xDB, 0xDC, 0xDD, 0xDE, 0xBC, 0xBE,
-    0x7C, 0x7D, 0x7E, 0x7F, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
-    0x20, 0x08, 0x2D, 0x2E, 0x24, 0x23, 0x21, 0x22
-  };
-
-  private static readonly byte[] alphaKeys = new byte[] {
-    0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A,
-    0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54,
-    0x55, 0x56, 0x57, 0x58, 0x59, 0x5A
-  };
-
-  private static readonly INPUT[] batch1Press;
-  private static readonly INPUT[] batch1Release;
-  private static readonly INPUT[] batch2Press;
-  private static readonly INPUT[] batch2Release;
-
-  static HybridClicker() {
-    batch1Press = new INPUT[1 + keys.Length];
-    batch1Press[0].type = 0;
-    batch1Press[0].u.mi.dwFlags = 0x0002;
-    for (int i = 0; i < keys.Length; i++) {
-      batch1Press[1 + i].type = 1;
-      batch1Press[1 + i].u.ki.wVk = keys[i];
-    }
-
-    batch1Release = new INPUT[1 + keys.Length];
-    batch1Release[0].type = 0;
-    batch1Release[0].u.mi.dwFlags = 0x0004;
-    for (int i = 0; i < keys.Length; i++) {
-      batch1Release[1 + i].type = 1;
-      batch1Release[1 + i].u.ki.wVk = keys[i];
-      batch1Release[1 + i].u.ki.dwFlags = 0x0002;
-    }
-
-    batch2Press = new INPUT[1 + alphaKeys.Length];
-    batch2Press[0].type = 1;
-    batch2Press[0].u.ki.wVk = 0x10;
-    for (int i = 0; i < alphaKeys.Length; i++) {
-      batch2Press[1 + i].type = 1;
-      batch2Press[1 + i].u.ki.wVk = alphaKeys[i];
-    }
-
-    batch2Release = new INPUT[alphaKeys.Length + 1];
-    for (int i = 0; i < alphaKeys.Length; i++) {
-      batch2Release[i].type = 1;
-      batch2Release[i].u.ki.wVk = alphaKeys[i];
-      batch2Release[i].u.ki.dwFlags = 0x0002;
-    }
-    batch2Release[alphaKeys.Length].type = 1;
-    batch2Release[alphaKeys.Length].u.ki.wVk = 0x10;
-    batch2Release[alphaKeys.Length].u.ki.dwFlags = 0x0002;
-  }
-
   public static void Smash() {
     SendInput((uint)batch1Press.Length, batch1Press, inputSize);
     Thread.Sleep(15);
@@ -762,7 +256,124 @@ ${SENDINPUT_TYPES}
     SendInput((uint)batch2Release.Length, batch2Release, inputSize);
     Thread.Sleep(10);
   }
+
+  public static string RunTimed(int seconds) {
+    Stopwatch sw = Stopwatch.StartNew();
+    long cycles = 0;
+    long targetMs = seconds * 1000L;
+    while (sw.ElapsedMilliseconds < targetMs) {
+      Smash();
+      cycles++;
+    }
+    sw.Stop();
+    long totalActions = cycles * actionsPerCycle;
+    return "Done. Cycles: " + cycles + ", Total actions: " + totalActions + " in " + sw.ElapsedMilliseconds + "ms";
+  }
+}`;
+
+// Shared C# MouseClicker class for mouse-only modes.
+const MOUSE_CLICKER_CLASS = `using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public class MouseClicker {
+  [DllImport("user32.dll")]
+  public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint cButtons, uint dwExtraInfo);
+
+  public const uint MOUSEEVENTF_LEFTDOWN = 0x02;
+  public const uint MOUSEEVENTF_LEFTUP = 0x04;
+
+  public static void Click() {
+    mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
+    Thread.Sleep(20);
+    mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
+    Thread.Sleep(10);
+  }
+}`;
+
+// Duration of the timed clicker modes, in seconds.
+const CLICK_DURATION_SECONDS = 10;
+
+// ── PowerShell script templates ──
+
+const MOUSE_TIMED_SCRIPT = `
+try {
+  Write-Output "Starting clicker for ${CLICK_DURATION_SECONDS} seconds..."
+  Add-Type -TypeDefinition @'
+${MOUSE_CLICKER_CLASS}
+'@
+  Write-Output "Clicker class loaded successfully"
+  $startTime = Get-Date
+  $endTime = $startTime.AddSeconds(${CLICK_DURATION_SECONDS})
+  Write-Output "Start time: $startTime"
+  Write-Output "End time: $endTime"
+  $count = 0
+  while ($true) {
+    $currentTime = Get-Date
+    if ($currentTime -ge $endTime) {
+      Write-Output "Time limit reached"
+      break
+    }
+    try {
+      [MouseClicker]::Click()
+      $count++
+      if ($count % 10 -eq 0) {
+        Write-Output "Clicked $count times at $currentTime"
+      }
+    } catch {
+      Write-Output "Click error: $_"
+      Write-Output "Stack: $($_.ScriptStackTrace)"
+    }
+  }
+  Write-Output "Done. Total clicks: $count"
+} catch {
+  Write-Output "Fatal error: $_"
+  Write-Output "Stack: $($_.ScriptStackTrace)"
 }
+`;
+
+const MOUSE_INFINITE_SCRIPT = `
+try {
+  Write-Output "Starting infinite clicker (ESC to stop)..."
+  Add-Type -TypeDefinition @'
+${MOUSE_CLICKER_CLASS}
+'@
+  Write-Output "Clicker class loaded successfully"
+  $count = 0
+  while ($true) {
+    try {
+      [MouseClicker]::Click()
+      $count++
+      if ($count % 10 -eq 0) {
+        Write-Output "Clicked $count times"
+      }
+    } catch {
+      Write-Output "Click error: $_"
+      Write-Output "Stack: $($_.ScriptStackTrace)"
+    }
+  }
+} catch {
+  Write-Output "Fatal error: $_"
+  Write-Output "Stack: $($_.ScriptStackTrace)"
+}
+`;
+
+const HYBRID_TIMED_SCRIPT = `
+try {
+  Add-Type -TypeDefinition @'
+${HYBRID_CLICKER_CLASS}
+'@
+  Write-Output ([HybridClicker]::RunTimed(${CLICK_DURATION_SECONDS}))
+} catch {
+  Write-Output "Fatal error: $_"
+  Write-Output "Stack: $($_.ScriptStackTrace)"
+}
+`;
+
+const HYBRID_INFINITE_SCRIPT = `
+try {
+  Add-Type -TypeDefinition @'
+${HYBRID_CLICKER_CLASS}
 '@
   while ($true) {
     [HybridClicker]::Smash()
@@ -773,13 +384,13 @@ ${SENDINPUT_TYPES}
 }
 `;
 
-  mainWindow.webContents.send("log", "Creating temp directory script...");
-  const scriptPath = uniqueScriptPath("hybrid-clicker-infinite");
-  mainWindow.webContents.send("log", "Script path: " + scriptPath);
-  fs.writeFileSync(scriptPath, powerShellScript);
-  mainWindow.webContents.send("log", "Script written successfully");
-
-  mainWindow.webContents.send("log", "Starting PowerShell process...");
+// Spawn a clicker PowerShell script and wire up the common lifecycle:
+// stdout/stderr forwarding, temp-file cleanup, ESC handling and renderer replies.
+// reportExitCode: when true, a non-zero exit is reported as clicker-error
+// (timed modes); infinite modes only ever complete or get stopped.
+function runClickerScript({ name, script, event, reportExitCode }) {
+  const scriptPath = uniqueScriptPath(name);
+  fs.writeFileSync(scriptPath, script);
 
   const ps = spawn("powershell.exe", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
     windowsHide: true,
@@ -787,48 +398,264 @@ ${SENDINPUT_TYPES}
   clickerProcess = ps;
   registerGlobalEsc();
 
-  mainWindow.webContents.send("log", "PowerShell process started with PID: " + ps.pid);
+  sendToRenderer("log", `${name} started with PID: ${ps.pid}`);
 
   ps.stdout.on("data", (data) => {
-    mainWindow.webContents.send("ps-output", data.toString());
+    sendToRenderer("ps-output", data.toString());
   });
 
   ps.stderr.on("data", (data) => {
-    mainWindow.webContents.send("ps-error", data.toString());
+    sendToRenderer("ps-error", data.toString());
   });
 
   ps.on("close", (code) => {
-    mainWindow.webContents.send("log", "Hybrid-infinite closed with code: " + code);
+    sendToRenderer("log", `${name} closed with code: ${code}`);
     const wasKilled = clickerProcess !== ps;
     if (clickerProcess === ps) clickerProcess = null;
     stopMouseMove();
     unregisterGlobalEsc();
     try {
       fs.unlinkSync(scriptPath);
-    } catch (_e) {
-      _e;
+    } catch {
+      // temp file already gone — nothing to clean up
     }
     if (wasKilled) {
       event.reply("clicker-stopped");
-    } else {
+    } else if (!reportExitCode || code === 0) {
       event.reply("clicker-complete");
+    } else {
+      event.reply("clicker-error", `Exit code: ${code}`);
     }
   });
 
   ps.on("error", (err) => {
-    mainWindow.webContents.send("log", "Hybrid-infinite error: " + err);
+    sendToRenderer("log", `${name} error: ${err}`);
     if (clickerProcess === ps) clickerProcess = null;
     event.reply("clicker-error", err.message);
   });
+}
+
+// Guard against starting a second action while one is already running.
+// Buttons are disabled in the renderer, but defend on the main side too so a
+// stray IPC message can't orphan the running PowerShell process.
+function isClickerBusy(channel) {
+  if (clickerProcess || moveProcess) {
+    sendToRenderer("log", `Already running, ignoring ${channel}`);
+    return true;
+  }
+  return false;
+}
+
+// Returns true if a mouse-move process was actually spawned, false otherwise.
+// onClose (optional) is invoked when that process exits — used by the move-only
+// mode to signal completion without polling.
+function startMouseMoveIfNeeded(coords, withClick = false, onClose = null) {
+  sendToRenderer("log", "startMouseMoveIfNeeded called, coords: " + JSON.stringify(coords));
+  if (!coords || coords.length === 0) {
+    sendToRenderer("log", "No coordinates, skipping mouse move");
+    return false;
+  }
+
+  // Validate IPC data: coerce to integers and drop anything non-numeric so
+  // nothing but plain numbers is ever interpolated into the PowerShell script.
+  const sanitized = coords
+    .map((c) => ({
+      x: Math.trunc(Number(c.x)),
+      y: Math.trunc(Number(c.y)),
+      interval: Math.trunc(Number(c.interval)),
+    }))
+    .filter((c) => Number.isFinite(c.x) && Number.isFinite(c.y) && Number.isFinite(c.interval));
+
+  if (sanitized.length === 0) {
+    sendToRenderer("log", "No valid coordinates after validation, skipping mouse move");
+    return false;
+  }
+
+  const coordsArray = sanitized
+    .map((c) => `[PSCustomObject]@{X=${c.x};Y=${c.y};Interval=${c.interval}}`)
+    .join(",");
+
+  const clickerClass = withClick
+    ? `
+public class MouseClicker {
+  [DllImport("user32.dll")]
+  public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint cButtons, uint dwExtraInfo);
+
+  public const uint MOUSEEVENTF_LEFTDOWN = 0x02;
+  public const uint MOUSEEVENTF_LEFTUP = 0x04;
+
+  public static void Click() {
+    mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
+    Thread.Sleep(20);
+    mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
+    Thread.Sleep(10);
+  }
+}`
+    : "";
+
+  const clickCall = withClick ? `\n      [MouseClicker]::Click()` : "";
+
+  const moveScript = `
+try {
+  Write-Output "Starting mouse mover with ${sanitized.length} coordinates..."
+  Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public class MouseMover {
+  [DllImport("user32.dll", SetLastError = true)]
+  public static extern bool SetCursorPos(int x, int y);
+
+  public static void MoveTo(int x, int y) {
+    SetCursorPos(x, y);
+  }
+}
+${clickerClass}
+'@
+
+  Write-Output "Mouse mover class loaded successfully"
+  $coordinates = @(${coordsArray})
+  $index = 0
+  while ($true) {
+    try {
+      $coord = $coordinates[$index]
+      $x = $coord.X
+      $y = $coord.Y
+      $interval = $coord.Interval
+      Write-Output "Moving to: X=$x, Y=$y"
+      [MouseMover]::MoveTo($x, $y)${clickCall}
+      Start-Sleep -Milliseconds $interval
+      $index++
+      if ($index -ge $coordinates.Length) {
+        $index = 0
+      }
+    } catch {
+      Write-Output "Move error: $_"
+    }
+  }
+} catch {
+  Write-Output "Fatal error: $_"
+}
+`;
+
+  const scriptPath = uniqueScriptPath("mouse-move");
+  fs.writeFileSync(scriptPath, moveScript);
+  sendToRenderer("log", "Mouse move script: " + scriptPath);
+
+  const ps = spawn("powershell.exe", ["-ExecutionPolicy", "Bypass", "-File", scriptPath], {
+    windowsHide: true,
+  });
+  moveProcess = ps;
+
+  sendToRenderer("log", "Mouse move started with PID: " + ps.pid);
+
+  ps.stdout.on("data", (data) => {
+    sendToRenderer("ps-output", data.toString());
+  });
+
+  ps.stderr.on("data", (data) => {
+    sendToRenderer("ps-error", data.toString());
+  });
+
+  ps.on("close", () => {
+    if (moveProcess === ps) moveProcess = null;
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch {
+      // temp file already gone — nothing to clean up
+    }
+    if (onClose) onClose();
+  });
+
+  ps.on("error", (err) => {
+    sendToRenderer("log", "Mouse move error: " + err);
+    if (moveProcess === ps) moveProcess = null;
+  });
+
+  return true;
+}
+
+ipcMain.on("start-moving-mouse", (event, data) => {
+  if (isClickerBusy("start-moving-mouse")) return;
+  sendToRenderer("log", "Start moving mouse requested");
+  registerGlobalEsc();
+
+  const finish = () => {
+    unregisterGlobalEsc();
+    event.reply("clicker-complete");
+  };
+
+  // The mover runs an infinite loop, so completion only happens when the
+  // process is killed (ESC / stop). Signal via the process close event.
+  const started = startMouseMoveIfNeeded(data.coordinates, true, finish);
+  if (!started) finish();
 });
 
-ipcMain.on("get-window-position", (event) => {
-  const position = mainWindow.getPosition();
-  event.reply("window-position", position);
+ipcMain.on("start-clicker", (event, data) => {
+  if (isClickerBusy("start-clicker")) return;
+  sendToRenderer("log", "IPC start-clicker received, data: " + JSON.stringify(data));
+  if (data) startMouseMoveIfNeeded(data.coordinates);
+  runClickerScript({ name: "clicker", script: MOUSE_TIMED_SCRIPT, event, reportExitCode: true });
+});
+
+ipcMain.on("start-clicker-infinite", (event, data) => {
+  if (isClickerBusy("start-clicker-infinite")) return;
+  sendToRenderer("log", "IPC start-clicker-infinite received");
+  if (data) startMouseMoveIfNeeded(data.coordinates);
+  runClickerScript({
+    name: "clicker-infinite",
+    script: MOUSE_INFINITE_SCRIPT,
+    event,
+    reportExitCode: false,
+  });
+});
+
+ipcMain.on("stop-clicker", () => {
+  sendToRenderer("log", "Stop clicker requested");
+  const hadClicker = !!clickerProcess;
+  if (clickerProcess) {
+    sendToRenderer("log", "Killing clicker PID: " + clickerProcess.pid);
+    spawn("taskkill", ["/PID", String(clickerProcess.pid), "/T", "/F"]);
+    clickerProcess = null;
+    releaseAllKeys();
+  }
+  if (moveProcess) {
+    sendToRenderer("log", "Killing move PID: " + moveProcess.pid);
+    spawn("taskkill", ["/PID", String(moveProcess.pid), "/T", "/F"]);
+    moveProcess = null;
+  }
+  if (!hadClicker) {
+    sendToRenderer("clicker-stopped");
+  }
+});
+
+ipcMain.on("start-hybrid-clicker", (event, data) => {
+  if (isClickerBusy("start-hybrid-clicker")) return;
+  sendToRenderer("log", "IPC start-hybrid-clicker received");
+  if (data) startMouseMoveIfNeeded(data.coordinates);
+  runClickerScript({
+    name: "hybrid-clicker",
+    script: HYBRID_TIMED_SCRIPT,
+    event,
+    reportExitCode: true,
+  });
+});
+
+ipcMain.on("start-hybrid-clicker-infinite", (event, data) => {
+  if (isClickerBusy("start-hybrid-clicker-infinite")) return;
+  sendToRenderer("log", "IPC start-hybrid-clicker-infinite received");
+  if (data) startMouseMoveIfNeeded(data.coordinates);
+  runClickerScript({
+    name: "hybrid-clicker-infinite",
+    script: HYBRID_INFINITE_SCRIPT,
+    event,
+    reportExitCode: false,
+  });
 });
 
 ipcMain.on("capture-mouse-click", (event) => {
-  mainWindow.webContents.send("log", "Waiting for mouse click to capture coordinates...");
+  sendToRenderer("log", "Waiting for mouse click to capture coordinates...");
 
   const script = `
 Add-Type -TypeDefinition @'
@@ -882,7 +709,7 @@ while ($true) {
 
   ps.stdout.on("data", (data) => {
     output += data.toString();
-    mainWindow.webContents.send("ps-output", data.toString());
+    sendToRenderer("ps-output", data.toString());
     const coordMatch = output.match(/COORDS:(\d+),(\d+)/);
     if (coordMatch) {
       event.reply("mouse-click-captured", {
@@ -898,14 +725,14 @@ while ($true) {
   });
 
   ps.stderr.on("data", (data) => {
-    mainWindow.webContents.send("ps-error", data.toString());
+    sendToRenderer("ps-error", data.toString());
   });
 
   ps.on("close", () => {
     try {
       fs.unlinkSync(scriptPath);
-    } catch (_e) {
-      _e;
+    } catch {
+      // temp file already gone — nothing to clean up
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clicker-app",
-  "version": "1.0.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clicker-app",
-      "version": "1.0.0",
+      "version": "1.7.1",
       "license": "ISC",
       "devDependencies": {
         "electron": "^40.8.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "node --test \"test/**/*.test.js\"",
+    "test": "node --test",
     "start": "electron .",
     "build-win": "electron-builder --win --dir",
-    "rebuild-asar": "mkdir -p _tmp && cp -r main.js index.html package.json lib _tmp/ && npx asar pack _tmp dist/win-unpacked/resources/app.asar && rm -rf _tmp && echo 'app.asar rebuilt'",
+    "rebuild-asar": "rm -rf _tmp && mkdir _tmp _tmp/assets && cp -r main.js index.html package.json lib _tmp/ && cp assets/icon.ico _tmp/assets/ && npx asar pack _tmp dist/win-unpacked/resources/app.asar && rm -rf _tmp && echo 'app.asar rebuilt'",
     "lint": "eslint *.js lib test",
     "lint:fix": "eslint *.js lib test --fix",
     "format": "prettier --write *.js *.html *.md lib test",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "start": "electron .",
     "build-win": "electron-builder --win --dir",
     "rebuild-asar": "mkdir -p _tmp && cp -r main.js index.html package.json lib _tmp/ && npx asar pack _tmp dist/win-unpacked/resources/app.asar && rm -rf _tmp && echo 'app.asar rebuilt'",
-    "lint": "eslint *.js",
-    "lint:fix": "eslint *.js --fix",
-    "format": "prettier --write *.js *.html *.md",
-    "format:check": "prettier --check *.js *.html *.md"
+    "lint": "eslint *.js lib test",
+    "lint:fix": "eslint *.js lib test --fix",
+    "format": "prettier --write *.js *.html *.md lib test",
+    "format:check": "prettier --check *.js *.html *.md lib test"
   },
   "build": {
     "appId": "com.clicker.app",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "clicker-app",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test \"test/**/*.test.js\"",
     "start": "electron .",
-    "build-win": "electron-builder --win",
-    "rebuild-asar": "mkdir -p _tmp && cp main.js index.html package.json .eslintrc.js _tmp/ && npx asar pack _tmp dist/win-unpacked/resources/app.asar && rm -rf _tmp && echo 'app.asar rebuilt'",
+    "build-win": "electron-builder --win --dir",
+    "rebuild-asar": "mkdir -p _tmp && cp -r main.js index.html package.json lib _tmp/ && npx asar pack _tmp dist/win-unpacked/resources/app.asar && rm -rf _tmp && echo 'app.asar rebuilt'",
     "lint": "eslint *.js",
     "lint:fix": "eslint *.js --fix",
-    "format": "prettier --write *.js *.html *.md"
+    "format": "prettier --write *.js *.html *.md",
+    "format:check": "prettier --check *.js *.html *.md"
   },
   "build": {
     "appId": "com.clicker.app",
@@ -19,6 +20,7 @@
       "main.js",
       "index.html",
       "package.json",
+      "lib/**/*.js",
       "assets/icon.ico"
     ],
     "win": {

--- a/test/coordinates.test.js
+++ b/test/coordinates.test.js
@@ -75,3 +75,62 @@ test("getCoords returns the array or null when empty", () => {
   const coords = [{ x: 1, y: 1, interval: 1000 }];
   assert.equal(coord.getCoords(coords), coords);
 });
+
+// ── characterization tests: intentionally preserved legacy behavior ──
+
+test("parseInterval truncates float strings like the old parseInt", () => {
+  assert.equal(coord.parseInterval("10.5"), 10);
+});
+
+test("addCoordinate preserves legacy quirks for exotic numeric strings", () => {
+  // `parseInt("1e3") || 5000` → 1: below MIN_INTERVAL but truthy, kept as-is
+  assert.equal(coord.addCoordinate([], { x: 1, y: 2, interval: "1e3" })[0].interval, 1);
+  // negative values are truthy too — min="10" on the input does not block typing
+  assert.equal(coord.addCoordinate([], { x: 1, y: 2, interval: "-5" })[0].interval, -5);
+});
+
+// ── sanitizeCoordinates: main-process IPC validation ──
+
+test("sanitizeCoordinates returns [] for non-array payloads", () => {
+  assert.deepEqual(coord.sanitizeCoordinates(null), []);
+  assert.deepEqual(coord.sanitizeCoordinates(undefined), []);
+  assert.deepEqual(coord.sanitizeCoordinates("abc"), []);
+  assert.deepEqual(coord.sanitizeCoordinates({ length: 1 }), []);
+  assert.deepEqual(coord.sanitizeCoordinates(5), []);
+});
+
+test("sanitizeCoordinates truncates values to plain integers", () => {
+  assert.deepEqual(coord.sanitizeCoordinates([{ x: "10.7", y: 20.2, interval: "5000" }]), [
+    { x: 10, y: 20, interval: 5000 },
+  ]);
+});
+
+test("sanitizeCoordinates drops non-numeric and malformed entries", () => {
+  const input = [
+    { x: "abc", y: 1, interval: 100 },
+    { x: 1, y: {}, interval: 100 },
+    { x: 1, y: 1 },
+    null,
+    "junk",
+    { x: 5, y: 6, interval: 700 },
+  ];
+  assert.deepEqual(coord.sanitizeCoordinates(input), [{ x: 5, y: 6, interval: 700 }]);
+});
+
+test("sanitizeCoordinates clamps coordinates to the int32 range", () => {
+  const [c] = coord.sanitizeCoordinates([{ x: 1e21, y: -1e21, interval: 100 }]);
+  assert.deepEqual(c, { x: 2147483647, y: -2147483648, interval: 100 });
+});
+
+test("sanitizeCoordinates clamps the interval to [MIN_INTERVAL, int32 max]", () => {
+  // Start-Sleep -Milliseconds binds to Int32 and rejects negatives: out-of-range
+  // values would otherwise error on every loop iteration with no sleep at all.
+  // The floor is MIN_INTERVAL (not 0) so a stray sub-minimum value (the UI
+  // minimum is 10) can never turn the mover into a zero-sleep busy loop.
+  const [c] = coord.sanitizeCoordinates([{ x: 1, y: 2, interval: 1e21 }]);
+  assert.equal(c.interval, 2147483647);
+  const [n] = coord.sanitizeCoordinates([{ x: 1, y: 2, interval: -5 }]);
+  assert.equal(n.interval, coord.MIN_INTERVAL);
+  const [z] = coord.sanitizeCoordinates([{ x: 1, y: 2, interval: 0 }]);
+  assert.equal(z.interval, coord.MIN_INTERVAL);
+});

--- a/test/coordinates.test.js
+++ b/test/coordinates.test.js
@@ -1,0 +1,77 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const coord = require("../lib/coordinates.js");
+
+test("parseInterval parses integers and rejects non-numbers", () => {
+  assert.equal(coord.parseInterval("5000"), 5000);
+  assert.equal(coord.parseInterval(250), 250);
+  assert.equal(coord.parseInterval("abc"), null);
+  assert.equal(coord.parseInterval(""), null);
+});
+
+test("isValidInterval enforces the minimum", () => {
+  assert.equal(coord.isValidInterval("5000"), true);
+  assert.equal(coord.isValidInterval("10"), true);
+  assert.equal(coord.isValidInterval("9"), false);
+  assert.equal(coord.isValidInterval("abc"), false);
+  assert.equal(coord.isValidInterval(""), false);
+});
+
+test("addCoordinate appends and uses the provided interval", () => {
+  const next = coord.addCoordinate([], { x: 100, y: 200, interval: "3000" });
+  assert.deepEqual(next, [{ x: 100, y: 200, interval: 3000 }]);
+});
+
+test("addCoordinate falls back to the default interval", () => {
+  assert.equal(
+    coord.addCoordinate([], { x: 1, y: 2, interval: "" })[0].interval,
+    coord.DEFAULT_INTERVAL
+  );
+  // matches the old `parseInt() || 5000`: 0 is treated as falsy → default
+  assert.equal(
+    coord.addCoordinate([], { x: 1, y: 2, interval: 0 })[0].interval,
+    coord.DEFAULT_INTERVAL
+  );
+});
+
+test("addCoordinate does not mutate the input array", () => {
+  const original = [{ x: 1, y: 1, interval: 1000 }];
+  coord.addCoordinate(original, { x: 2, y: 2, interval: 2000 });
+  assert.equal(original.length, 1);
+});
+
+test("replaceCoordinate keeps the existing interval", () => {
+  const coords = [{ x: 1, y: 1, interval: 1000 }];
+  const next = coord.replaceCoordinate(coords, 0, { x: 9, y: 9 });
+  assert.deepEqual(next, [{ x: 9, y: 9, interval: 1000 }]);
+});
+
+test("replaceCoordinate ignores out-of-range indexes", () => {
+  const coords = [{ x: 1, y: 1, interval: 1000 }];
+  assert.equal(coord.replaceCoordinate(coords, 5, { x: 9, y: 9 }), coords);
+  assert.equal(coord.replaceCoordinate(coords, -1, { x: 9, y: 9 }), coords);
+});
+
+test("removeCoordinate removes by index without mutating", () => {
+  const coords = [
+    { x: 1, y: 1, interval: 1000 },
+    { x: 2, y: 2, interval: 2000 },
+  ];
+  const next = coord.removeCoordinate(coords, 0);
+  assert.deepEqual(next, [{ x: 2, y: 2, interval: 2000 }]);
+  assert.equal(coords.length, 2);
+});
+
+test("updateInterval applies valid intervals and rejects invalid ones", () => {
+  const coords = [{ x: 1, y: 1, interval: 1000 }];
+  assert.equal(coord.updateInterval(coords, 0, "2500")[0].interval, 2500);
+  // invalid (< MIN_INTERVAL) → unchanged list returned
+  assert.equal(coord.updateInterval(coords, 0, "5"), coords);
+  assert.equal(coord.updateInterval(coords, 0, "abc"), coords);
+});
+
+test("getCoords returns the array or null when empty", () => {
+  assert.equal(coord.getCoords([]), null);
+  const coords = [{ x: 1, y: 1, interval: 1000 }];
+  assert.equal(coord.getCoords(coords), coords);
+});


### PR DESCRIPTION
Рефакторинг по итогам ревью всего проекта + исправления по итогам ревью самого PR. Patch-релиз `1.7.0 → 1.7.1`. Набор VK-клавиш сверен байт-в-байт с прежней версией (механически, поэлементно), F1-F12 по-прежнему отсутствуют.

## Задачи (по приоритету)

### 🔴 Дедупликация
1. **Единый источник VK-клавиш** — `HYBRID_KEYS` + `toCSharpBytes()`, генерится во все 3 скрипта (раньше 3 копии → риск рассинхрона и случайного возврата F1-F12).
2. **Дедуп `HybridClicker`** — один общий C#-класс с `Smash()`+`RunTimed()` вместо ~80 строк, продублированных дважды.
3. **Хелпер `runClickerScript({...})`** — общий спавн PowerShell вместо boilerplate в 4 хендлерах.

### 🟠 Безопасность/устойчивость
4. **Валидация координат** в main — `sanitizeCoordinates()` из `lib/coordinates.js`: non-array payload → `[]`, отброс мусорных элементов, `Math.trunc(Number())`, clamp x/y в int32 и interval в `[MIN_INTERVAL, int32 max]` до инъекции в PS.
5. **Guard от параллельного запуска** — `isClickerBusy()` в 5 хендлерах (защита на стороне main, не только в UI).

### 🟡 Чистка/качество
6. Удалён мёртвый IPC-канал `get-window-position`.
7. Удалены мёртвые слушатели `move-complete`/`move-stopped`/`move-error` в рендерере.
8. Убрана лишняя обёртка `ClickWithDelay()`.
9. `catch (_e) { _e; }` → `catch {}` с комментарием (обход `no-empty` без правки `.eslintrc.js`).
10. Унифицирован биндинг событий в рендерере (inline `onchange`/`window.*` → `addEventListener`).
11. Null-guard `mainWindow` через хелпер `sendToRenderer()` (защита от send на destroyed-окно).
12. Хардкод «10 сек» → константа `CLICK_DURATION_SECONDS`.
13. `.eslintrc.js` убран из паковки `rebuild-asar`.
14. `build-win` → `electron-builder --win --dir` (только `win-unpacked`, без портативного exe).

### 🟢 Тесты/инфра
15. Завершение move-режима переведено с `setInterval`-поллинга на событийную модель.
16. Чистая логика координат вынесена в `lib/coordinates.js`, покрыта тестами `test/coordinates.test.js` (встроенный `node --test`, без внешних зависимостей).

## Исправления по итогам ревью PR (df7ddb1)

- **Утечка глобального Esc**: в `start-moving-mouse` шорткат регистрируется только после успешного старта мувера — throw внутри больше не оставляет Escape захваченным системно.
- **Guard контейнера**: `sanitizeCoordinates()` отбрасывает non-array payload и мусорные элементы — stray IPC больше не роняет main uncaught TypeError'ом.
- **Int32-clamp интервала**: значения вне `[10, 2147483647]` больше не превращают PS-цикл в вечный error-loop без сна (`Start-Sleep` биндится в Int32 и не принимает отрицательные).
- **Ровно один reply**: `replyOnce` в `runClickerScript` — при сбое спавна рендерер больше не получает `clicker-error` + `clicker-stopped` парой (комментарий про «error без close» был фактически неверен и исправлен).
- **CI гоняет тесты**: шаг `npm test` в workflow, Node 20 → 22; тест-скрипт — `node --test` (конвенционный поиск, работает на Node 20+, прежний glob требовал Node ≥ 21).
- **`capture-mouse-click`**: процесс отслеживается, новый запрос вытесняет предыдущий поллер (раньше двойной клик «Change position» приводил к двум ответам на один физический клик), `window-all-closed` убивает и его; `uniqueScriptPath` получил счётчик против коллизий в одну миллисекунду.
- **`rebuild-asar`**: чистит `_tmp` в начале (stale-файлы не попадают в asar) и кладёт `assets/icon.ico` — теперь состав идентичен сборке electron-builder.
- Пиннинг-тесты легаси-причуд (`'1e3'` → 1, `'-5'` → −5 в add-path) + 6 тестов `sanitizeCoordinates` — всего 17.

## ⚠️ Осознанные поведенческие дельты (edge-cases)

Базовый рефакторинг поведение не менял (сверено хендлер-за-хендлером с master), но несколько граничных случаев осознанно улучшены:

- Stale `editingIndex` (удалили точку во время pending-захвата) раньше кидал TypeError и навсегда блокировал кнопку «Add point»; теперь — тихий no-op, кнопка восстанавливается.
- Интервалы вне `[10, int32]` теперь клампятся (раньше — вечный error-loop в PS).
- `parseInt` с явным radix 10: hex-строки вида `'0x1F'` больше не парсятся (через `<input type="number">` недостижимо).
- Spawn-error пути: temp-скрипт удаляется и в `capture-mouse-click`; рендерер получает ровно один финальный reply.
- Повторный запрос захвата вытесняет предыдущий, а не работает параллельно с ним.

## Проверки
- `node --check main.js` ✅
- `npm run lint` ✅
- `npm test` → 17/17 ✅ (локально Node 24; отдельно проверено на реальном Node 20.19.0 — 17/17)
- `npm run format:check` ✅
- Набор клавиш идентичен прод-версии, F1-F12 отсутствуют ✅

## ⚠️ Требует ручного smoke-теста на Windows
GUI не запускался (CI/dev на Linux). Перед мержем прогнать .exe: окно открывается, координаты добавляются/удаляются, интервал валидируется, кликеры стартуют/останавливаются по ESC. Особое внимание — `require("./lib/coordinates.js")` в рендерере и в main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
